### PR TITLE
Add hashing of input data

### DIFF
--- a/mapclientplugins/pointcloudpartitionerstep/step.py
+++ b/mapclientplugins/pointcloudpartitionerstep/step.py
@@ -62,7 +62,6 @@ class PointCloudPartitionerStep(WorkflowStepMountPoint):
         self._view.set_location(os.path.join(self._location, self._config['identifier']))
         self._view.clear()
         self._view.load(self._source_points, self._segmentation_surface)
-        self._view.load_settings()
         self._setCurrentWidget(self._view)
 
     def _my_done_execution(self):


### PR DESCRIPTION
This PR introduces hashing of the point cloud input data to the step settings.

Before loading the point cloud into the points region we now generate a hash of the point cloud input data and check it against the hash of the input data that was used last time this step was opened. The previous output file will be reloaded if the current input data matches the previous input data.

The hash of the point cloud input data is saved to the step settings when closing the step.