### PR TITLE
Selection group bug fix

### DIFF
--- a/mapclientplugins/pointcloudpartitionerstep/model/pointcloudpartitionermodel.py
+++ b/mapclientplugins/pointcloudpartitionerstep/model/pointcloudpartitionermodel.py
@@ -3,8 +3,6 @@ Created: April, 2023
 
 @author: tsalemink
 """
-from cmlibs.utils.zinc.field import find_or_create_field_group
-from cmlibs.utils.zinc.general import ChangeManager
 from cmlibs.utils.zinc.region import convert_nodes_to_datapoints
 from cmlibs.utils.zinc.scene import scene_create_selection_group
 from cmlibs.zinc.context import Context
@@ -21,20 +19,16 @@ class PointCloudPartitionerModel(object):
         self._mesh = None
 
         self._context = Context("PointCloudPartitioner")
-        root_region = self._context.getDefaultRegion()
-        self._points_region = root_region.createChild("points")
-        self._label_region = root_region.createChild("label")
-        self._surfaces_region = root_region.createChild("surfaces")
-
-        # TODO: Try this...
-        self._root_region = root_region
+        self._root_region = self._context.getDefaultRegion()
+        self._points_region = self._root_region.createChild("points")
+        self._label_region = self._root_region.createChild("label")
+        self._surfaces_region = self._root_region.createChild("surfaces")
 
         self.define_standard_materials()
         self.define_standard_glyphs()
 
         self._selection_filter = self._create_selection_filter()
 
-    # TODO: ???
     def get_root_region(self):
         return self._root_region
 

--- a/mapclientplugins/pointcloudpartitionerstep/view/pointcloudpartitionerwidget.py
+++ b/mapclientplugins/pointcloudpartitionerstep/view/pointcloudpartitionerwidget.py
@@ -626,13 +626,13 @@ class PointCloudPartitionerWidget(QtWidgets.QWidget):
         _select_elements(field_module, mesh_selection_group, el_ids[0])
 
     def _get_node_selection_group(self):
-        selection_field = self._model.get_point_selection_group()
+        scene = self._ui.widgetZinc.get_zinc_sceneviewer().getScene()
+        selection_field = scene_get_or_create_selection_group(scene)
         return selection_field.getOrCreateNodesetGroup(self._model.get_data_points())
 
-    # TODO; Why is this not returning the same object each time...??????
     def _get_mesh_selection_group(self):
-        region = self._model.get_surfaces_region()
-        selection_field = scene_get_or_create_selection_group(region.getScene())
+        scene = self._ui.widgetZinc.get_zinc_sceneviewer().getScene()
+        selection_field = scene_get_or_create_selection_group(scene)
         return selection_field.getMeshGroup(self._model.get_mesh())
 
     def _get_checked_group(self):

--- a/mapclientplugins/pointcloudpartitionerstep/view/zincpointcloudpartitionerwidget.py
+++ b/mapclientplugins/pointcloudpartitionerstep/view/zincpointcloudpartitionerwidget.py
@@ -32,6 +32,10 @@ class ZincPointCloudPartitionerWidget(BaseSceneviewerWidget):
         super()._activate_handler(handler)
         self.handler_updated.emit()
 
+    def mouse_enter_event(self, event):
+        super().mouse_enter_event(event)
+        self.setFocus()
+
     def mouse_release_event(self, event):
         if isinstance(self.get_active_handler(), SceneSelection):
             super().mouse_release_event(event)


### PR DESCRIPTION
This PR addresses a bug we've been encountering where the UI select buttons don't always add the points to the correct selection field group. It appears that the `SceneSelection` handler and the plugin were using different `Scene` objects which was giving unwanted behavior is some situations.

@hsorby, could you try out these changes if you get a chance and let me know if you can see any issues.